### PR TITLE
Added AudioHandling class and volume controls

### DIFF
--- a/SamplePlugin/Audio/AudioHandler.cs
+++ b/SamplePlugin/Audio/AudioHandler.cs
@@ -1,0 +1,112 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using NAudio.Wave;
+using NAudio.Wave.SampleProviders;
+
+namespace EldenRing.Audio
+{
+    public enum AudioTrigger
+    {
+        Death
+    }
+
+    // Cached sound concept lovingly borrowed from: https://markheath.net/post/fire-and-forget-audio-playback-with
+    class CachedSound
+    {
+        internal float[] AudioData { get; private set; }
+        internal WaveFormat WaveFormat { get; private set; }
+        internal CachedSound(string audioFileName)
+        {
+            using (var audioFileReader = new AudioFileReader(audioFileName))
+            {
+                WaveFormat = audioFileReader.WaveFormat;
+                var wholeFile = new List<float>((int)(audioFileReader.Length / 4));
+                var readBuffer = new float[audioFileReader.WaveFormat.SampleRate * audioFileReader.WaveFormat.Channels];
+                int samplesRead;
+                while ((samplesRead = audioFileReader.Read(readBuffer, 0, readBuffer.Length)) > 0)
+                {
+                    wholeFile.AddRange(readBuffer.Take(samplesRead));
+                }
+                AudioData = wholeFile.ToArray();
+            }
+        }
+    }
+
+    class CachedSoundSampleProvider : ISampleProvider
+    {
+        private readonly CachedSound cachedSound;
+        private long position;
+
+        public CachedSoundSampleProvider(CachedSound cachedSound)
+        {
+            this.cachedSound = cachedSound;
+        }
+
+        public int Read(float[] buffer, int offset, int count)
+        {
+            var availableSamples = cachedSound.AudioData.Length - position;
+            var samplesToCopy = Math.Min(availableSamples, count);
+            Array.Copy(cachedSound.AudioData, position, buffer, offset, samplesToCopy);
+            position += samplesToCopy;
+            return (int)samplesToCopy;
+        }
+
+        public WaveFormat WaveFormat { get { return cachedSound.WaveFormat; } }
+    }
+
+    public class AudioHandler
+    {
+        private readonly IWavePlayer outputDevice;
+        private readonly Dictionary<AudioTrigger, CachedSound> sounds;
+        private readonly VolumeSampleProvider sampleProvider;
+        private readonly MixingSampleProvider mixer;
+
+        public float Volume
+        {
+            get => sampleProvider.Volume;
+            set
+            {
+                sampleProvider.Volume = value;
+                
+            }
+        }
+
+        public AudioHandler(string deathPath)
+        {
+            outputDevice = new WaveOutEvent();
+            sounds = new Dictionary<AudioTrigger, CachedSound>();
+            sounds.Add(AudioTrigger.Death, new(deathPath));
+            mixer = new(WaveFormat.CreateIeeeFloatWaveFormat(48000, 2));
+            mixer.ReadFully = true;
+            sampleProvider = new(mixer);
+            outputDevice.Init(sampleProvider);
+            outputDevice.Play();
+        }
+
+        private ISampleProvider ConvertToRightChannelCount(ISampleProvider input)
+        {
+            if (input.WaveFormat.Channels == mixer.WaveFormat.Channels)
+            {
+                return input;
+            }
+            if (input.WaveFormat.Channels == 1 && mixer.WaveFormat.Channels == 2)
+            {
+                return new MonoToStereoSampleProvider(input);
+            }
+            throw new NotImplementedException("Not yet implemented this channel count conversion");
+        }
+
+
+        private void AddMixerInput(ISampleProvider input)
+        {
+            mixer.AddMixerInput(ConvertToRightChannelCount(input));
+        }
+
+        public void PlaySound(AudioTrigger trigger)
+        {
+            AddMixerInput(new CachedSoundSampleProvider(sounds[trigger]));
+        }
+        
+    }
+}

--- a/SamplePlugin/EldenRing.csproj
+++ b/SamplePlugin/EldenRing.csproj
@@ -52,6 +52,7 @@
 
   <ItemGroup>
     <PackageReference Include="DalamudPackager" Version="2.1.5" />
+    <PackageReference Include="NAudio" Version="2.0.1" />
     <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
     <PackageReference Include="System.Windows.Extensions" Version="6.0.0" />

--- a/SamplePlugin/Plugin.cs
+++ b/SamplePlugin/Plugin.cs
@@ -58,7 +58,6 @@ namespace EldenRing
         private readonly string synthesisFailsMessage;
 
         private readonly Stopwatch time = new Stopwatch();
-        //private readonly SoundPlayer player;
 
         private AudioHandler audioHandler { get; init; }
 


### PR DESCRIPTION
This PR adds more robust audio handling to the plugin.

I chose to replace `System.Media.AudioPlayer` with [NAudio](https://github.com/naudio/NAudio). Mostly due to the fact that the old setup didn't have the ability to control playback volume, but using NAudio also makes it relatively simple to cache the WAV data and queue up multiple sound effects at once. We could also do other dumb things with the audio in the future if desired. 

If more experienced C# developers know of something more lightweight than NAudio, or an easy way to strip out the unused modules I'd be happy to swap it out.