### PR TITLE
Updatre for 6.11

### DIFF
--- a/EldenRing/EldenRing.csproj
+++ b/EldenRing/EldenRing.csproj
@@ -3,10 +3,12 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>0.0.0.3</Version>
+    <Version>0.0.0.4</Version>
     <Description>Elden Ring April Fools addon</Description>
     <Copyright></Copyright>
     <PackageProjectUrl></PackageProjectUrl>
+	<NoWarn>IDE0003</NoWarn>
+	<NoWarn>CA1416</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -48,9 +50,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.5" />
+    <PackageReference Include="DalamudPackager" Version="2.1.6" />
     <PackageReference Include="NAudio" Version="2.0.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
     <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
     <PackageReference Include="System.Windows.Extensions" Version="6.0.0" />
     <Reference Include="FFXIVClientStructs">
@@ -84,6 +85,6 @@
   </ItemGroup>
 	<Target Name="CopyToDevPlugins" AfterTargets="Build" Condition="'$(Configuration)' == 'Debug'">
 		<Exec Command="if not exist $(AppData)\XIVLauncher\devPlugins\$(TargetName) (mkdir $(AppData)\XIVLauncher\devPlugins\$(TargetName))" />
-		<Exec Command='copy "$(TargetDir)*.*" "$(AppData)\XIVLauncher\devPlugins\$(TargetName)"' />
+		<Exec Command="copy &quot;$(TargetDir)*.*&quot; &quot;$(AppData)\XIVLauncher\devPlugins\$(TargetName)&quot;" />
 	</Target>
 </Project>

--- a/EldenRing/EldenRing.json
+++ b/EldenRing/EldenRing.json
@@ -4,10 +4,6 @@
   "Punchline": "Recreation of the Elden Ring April Fools joke.",
   "Description": "Currently under development with extra features, should currently function as the April Fools joke did.",
   "InternalName": "EldenRing",
-  "ApplicableVersion": "any",
-  "AssemblyVersion": "0.0.0.3",
-  "DalamudApiLevel": 5,
-  "LoadPriority": 0,
   "RepoUrl": "https://github.com/Roselyyn/EldenRingDalamud",
   "Tags": [
     "Elden Ring",

--- a/EldenRing/Plugin.cs
+++ b/EldenRing/Plugin.cs
@@ -162,8 +162,9 @@ namespace EldenRing
 
         private unsafe void GameNetworkOnNetworkMessage(IntPtr dataptr, ushort opcode, uint sourceactorid, uint targetactorid, NetworkMessageDirection direction)
         {
-            if (opcode != 0x301)
+            if (opcode != DataManager.ServerOpCodes["ActorControlSelf"]) // pull the opcode from Dalamud's definitions
                 return;
+            
 
             var cat = *(ushort*)(dataptr + 0x00);
             var updateType = *(uint*)(dataptr + 0x08);

--- a/EldenRing/Plugin.cs
+++ b/EldenRing/Plugin.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Media;
@@ -417,6 +417,11 @@ namespace EldenRing
 
         public void Dispose()
         {
+            PluginInterface.UiBuilder.Draw -= Draw;
+            framework.Update -= FrameworkOnUpdate;
+            chatGui.ChatMessage -= ChatGuiOnChatMessage;
+            gameNetwork.NetworkMessage -= GameNetworkOnNetworkMessage;
+
             erDeathBgTexture.Dispose();
             erNormalDeathTexture.Dispose();
             erCraftFailedTexture.Dispose();


### PR DESCRIPTION
Minor refactors to clean up some warnings when the plugin would dispose.
Cleaned out some entries from plugin manifest that weren't needed.
Updated dependencies.

Swapped hardcoded opcode to pulling from DalamudAssets. This should generally always be up to date unless it's literally patch day.